### PR TITLE
Allow specifying the state of the homebrew package

### DIFF
--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -127,7 +127,7 @@
       homebrew:
         name: "{{ item.name | default(item) }}"
         install_options: "{{ item.install_options | default(omit) }}"
-        state: present
+        state: "{{ item.state | default('present') }}"
       loop: "{{ homebrew_installed_packages }}"
       notify:
         - Clear homebrew cache


### PR DESCRIPTION
Adds the ability for the user to specify the state of homebrew package.

For instance if you want to install neovim 0.5.0 , it requires installing using `state: head`.