### PR TITLE
Use correct Homebrew directory permissions for M1 macs

### DIFF
--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -5,23 +5,34 @@
     homebrew_group: '{{ homebrew_group | default(ansible_user_gid) }}'
 
 # Homebrew setup prerequisites.
-- name: Ensure Homebrew parent directory has correct permissions (MacOS >= 10.13).
+- name: Ensure Homebrew parent directory has correct permissions (M1).
   file:
     path: "{{ homebrew_prefix }}"
-    owner: root
+    owner: "{{ homebrew_user }}"
     state: directory
   become: true
-  when: "ansible_distribution_version is version('10.13', '>=')"
+  when: ansible_machine == 'arm64'
 
-- name: Ensure Homebrew parent directory has correct permissions (MacOS < 10.13).
-  file:
-    path: "{{ homebrew_prefix }}"
-    owner: root
-    group: admin
-    state: directory
-    mode: 0775
-  become: true
-  when: "ansible_distribution_version is version('10.13', '<')"
+- name: Ensure Homebrew parent directory has correct permissions (Intel)
+  block:
+    - name: Ensure Homebrew parent directory has correct permissions (MacOS >= 10.13).
+      file:
+        path: "{{ homebrew_prefix }}"
+        owner: root
+        state: directory
+      become: true
+      when: "ansible_distribution_version is version('10.13', '>=')"
+
+    - name: Ensure Homebrew parent directory has correct permissions (MacOS < 10.13).
+      file:
+        path: "{{ homebrew_prefix }}"
+        owner: root
+        group: admin
+        state: directory
+        mode: 0775
+      become: true
+      when: "ansible_distribution_version is version('10.13', '<')"
+  when: ansible_machine == 'x86_64'
 
 - name: Ensure Homebrew directory exists.
   file:

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -13,7 +13,7 @@
   become: true
   when: ansible_machine == 'arm64'
 
-- name: Ensure Homebrew parent directory has correct permissions (Intel)
+- name: Ensure Homebrew parent directory has correct permissions (Intel).
   block:
     - name: Ensure Homebrew parent directory has correct permissions (MacOS >= 10.13).
       file:


### PR DESCRIPTION
When running the playbook on a Mac with an M1 processor, the playbook currently tries to change the `/opt/homebrew` directory to be owned by `root`. This is not how Homebrew installs itself natively, and should instead be owned by the `homebrew_user`.

Here's an example error message produced by the playbook:

```
failed: [jp-a8c-2021-imac.local] (item=gettext) => changed=false 
  ansible_loop_var: item
  item: gettext
  msg: |-
    Error: The following directories are not writable by your user:
    /opt/homebrew
  
    You should change the ownership of these directories to your user.
      sudo chown -R $(whoami) /opt/homebrew
  
    And make sure that your user has write permission.
      chmod u+w /opt/homebrew
```

This PR adjusts the playbook to handle Macs with an M1 chip correctly.