### PR TITLE
Replace bool filter with 'is truthy'

### DIFF
--- a/roles/mas/tasks/main.yml
+++ b/roles/mas/tasks/main.yml
@@ -14,8 +14,8 @@
   register: mas_signin_result
   when:
     - mas_account_result.rc == 1
-    - mas_email | bool
-    - mas_password | bool
+    - mas_email is truthy
+    - mas_password is truthy
     - not mas_signin_dialog
 
 - name: Sign in to MAS when email is provided, and complete password and 2FA using dialog.
@@ -24,7 +24,7 @@
   when:
     - mas_signin_dialog
     - mas_account_result.rc == 1
-    - mas_email | bool
+    - mas_email is truthy
 
 - name: List installed MAS apps.
   command: mas list


### PR DESCRIPTION
Replaces the ' | bool' filters with ' is truthy'.

I was havving issues with this always being false, even when I set the `mas_email` or `mas_password` values.  Having debugged the `mas_email` var to ensure it was making it in to the role correctly I [raised an issue on ansible](https://github.com/ansible/ansible/issues/75117), and was advised this is the correct way to check for non-empty strings.