### PR TITLE
Removed unneeded sudo password default

### DIFF
--- a/roles/homebrew/defaults/main.yml
+++ b/roles/homebrew/defaults/main.yml
@@ -21,8 +21,6 @@ homebrew_cask_uninstalled_apps: []
 homebrew_cask_appdir: /Applications
 homebrew_cask_accept_external_apps: false
 
-ansible_become_password: ""
-
 homebrew_use_brewfile: true
 homebrew_brewfile_dir: '~'
 


### PR DESCRIPTION
Fixes https://github.com/geerlingguy/mac-dev-playbook/issues/126, see issue for relevant discussion.

User can still pass the variable through `-e ansible_become_password=PASSWORD`, plus this _should_ be inherited from `-K/--ask-become-pass`