### PR TITLE
Pass binary path to brew bundle

### DIFF
--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -157,7 +157,7 @@
       check_mode: false
 
     - name: Install from Brewfile.
-      command: "brew bundle chdir={{ homebrew_brewfile_dir }}"
+      command: "{{ homebrew_brew_bin_path }}/brew bundle chdir={{ homebrew_brewfile_dir }}"
       when: homebrew_brewfile.stat.exists and homebrew_use_brewfile
 
   # Privilege escalation is only required for inner steps when


### PR DESCRIPTION
All other locations where brew is called use the correct explicit
prefix. However, installing from a Brewfile does not and this will fix
that.