### PR TITLE
Add timeout to dock commands

### DIFF
--- a/roles/dock/tasks/dock-add.yml
+++ b/roles/dock/tasks/dock-add.yml
@@ -10,7 +10,6 @@
 
 - name: Ensure Dock item {{ item.name | default(item) }} exists.
   ansible.builtin.command: "dockutil --add '{{ item.path }}'"
-  register: dockitem_added
   when: dockitem_exists.rc >0
   tags: ['dock']
 

--- a/roles/dock/tasks/dock-add.yml
+++ b/roles/dock/tasks/dock-add.yml
@@ -9,6 +9,13 @@
   tags: ['dock']
 
 - name: Ensure Dock item {{ item.name | default(item) }} exists.
-  ansible.builtin.shell: "dockutil --add '{{ item.path }}' && sleep 7"
+  ansible.builtin.command: "dockutil --add '{{ item.path }}'"
+  register: dockitem_added
+  when: dockitem_exists.rc >0
+  tags: ['dock']
+
+- name: Pause for 7 seconds between dock changes.
+  ansible.builtin.pause:
+    seconds: 7
   when: dockitem_exists.rc >0
   tags: ['dock']

--- a/roles/dock/tasks/dock-add.yml
+++ b/roles/dock/tasks/dock-add.yml
@@ -9,6 +9,6 @@
   tags: ['dock']
 
 - name: Ensure Dock item {{ item.name | default(item) }} exists.
-  ansible.builtin.command: "dockutil --add '{{ item.path }}'"
+  ansible.builtin.shell: "dockutil --add '{{ item.path }}' && sleep 7"
   when: dockitem_exists.rc >0
   tags: ['dock']

--- a/roles/dock/tasks/dock-remove.yml
+++ b/roles/dock/tasks/dock-remove.yml
@@ -12,7 +12,6 @@
 - name: Ensure Dock item {{ item }} is removed.
   ansible.builtin.command:
     cmd: dockutil --remove '{{ item }}'
-  register: dockitem_removed
   when: dockitem_exists.rc  == 0
   tags: ['dock']
 

--- a/roles/dock/tasks/dock-remove.yml
+++ b/roles/dock/tasks/dock-remove.yml
@@ -10,7 +10,14 @@
   tags: ['dock']
 
 - name: Ensure Dock item {{ item }} is removed.
-  ansible.builtin.shell:
-    cmd: dockutil --remove '{{ item }}' && sleep 7
+  ansible.builtin.command:
+    cmd: dockutil --remove '{{ item }}'
+  register: dockitem_removed
   when: dockitem_exists.rc  == 0
+  tags: ['dock']
+
+- name: Pause for 7 seconds between dock changes.
+  ansible.builtin.pause:
+    seconds: 7
+  when: dockitem_exists.rc == 0
   tags: ['dock']

--- a/roles/dock/tasks/dock-remove.yml
+++ b/roles/dock/tasks/dock-remove.yml
@@ -10,7 +10,7 @@
   tags: ['dock']
 
 - name: Ensure Dock item {{ item }} is removed.
-  ansible.builtin.command:
-    cmd: dockutil --remove '{{ item }}'
+  ansible.builtin.shell:
+    cmd: dockutil --remove '{{ item }}' && sleep 7
   when: dockitem_exists.rc  == 0
   tags: ['dock']


### PR DESCRIPTION
Hi Jeff,

It seems that dockutil is too fast for the ui to keep up with the
updates. Hence every playbook run removed/added only the first item
in the dock item lists.
Through trial an error I came to the magic number of 7 seconds
between each dockutil remove or add commands. With such a timeout
it seems to work fine.

This will close https://github.com/geerlingguy/ansible-collection-mac/issues/43