### PR TITLE
Application doesn't get added to dock if it's in your recent items

### DIFF
--- a/roles/dock/tasks/dock-add.yml
+++ b/roles/dock/tasks/dock-add.yml
@@ -8,13 +8,21 @@
   changed_when: false
   tags: ['dock']
 
+- name: Get current dock section from output.
+  set_fact:
+    current_section: "{{ dockitem_exists.stdout | regex_replace('^.*was found in (.*) at slot.*$', '\\1') }}"
+  when: dockitem_exists.rc == 0
+  tags: ['dock']
+
 - name: Ensure Dock item {{ item.name | default(item) }} exists.
   ansible.builtin.command: "dockutil --add '{{ item.path }}'"
-  when: dockitem_exists.rc >0
+  when: dockitem_exists.rc >0 or
+        dockitem_exists.rc == 0 and current_section == 'recent-apps'
   tags: ['dock']
 
 - name: Pause for 7 seconds between dock changes.
   ansible.builtin.pause:
     seconds: 7
-  when: dockitem_exists.rc >0
+  when: dockitem_exists.rc >0 or
+        dockitem_exists.rc == 0 and current_section == 'recent-apps'
   tags: ['dock']


### PR DESCRIPTION
This resolve the issue, if you have recent applications turned on for the dock and the application is in your recent applications the application doesn't get added to the persistent applications on the dock.

Resolves #54