### PR TITLE
Added --label flag when adding item to dock

### DIFF
--- a/roles/dock/tasks/dock-add.yml
+++ b/roles/dock/tasks/dock-add.yml
@@ -15,7 +15,7 @@
   tags: ['dock']
 
 - name: Ensure Dock item {{ item.name | default(item) }} exists.
-  ansible.builtin.command: "dockutil --add '{{ item.path }}'"
+  ansible.builtin.command: "dockutil --add '{{ item.path }}' --label '{{ item.name }}'"
   when: dockitem_exists.rc >0 or
         dockitem_exists.rc == 0 and current_section == 'recent-apps'
   tags: ['dock']


### PR DESCRIPTION
Fixes a bug that was causing the task `[geerlingguy.mac.dock : Move dock item to the correct position.]` to fail when the `item.name` was different from the app name listed in`item.path`.

Currently, the following example fails but should work as expected with this PR.
```
dockitems_persist:
  - name: "Things"
    path: "/Applications/Things3.app/"
    pos: 1
```