### PR TITLE
Fix homebrew package installation on ARM-based mac

### DIFF
--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -143,6 +143,7 @@
 
     - name: Ensure configured homebrew packages are installed.
       homebrew:
+        path: "{{ homebrew_brew_bin_path }}"
         name: "{{ item.name | default(item) }}"
         install_options: "{{ item.install_options | default(omit) }}"
         state: "{{ item.state | default('present') }}"


### PR DESCRIPTION
This PR fixes https://github.com/geerlingguy/ansible-collection-mac/issues/72 by including the explicit path. 

I've tested successfully in an M1 Macbook.  