### PR TITLE
feat(homebrew): Add option to upgrade all casks

### DIFF
--- a/roles/homebrew/README.md
+++ b/roles/homebrew/README.md
@@ -38,6 +38,11 @@ Packages you would like to make sure are _uninstalled_.
 
 Whether to upgrade homebrew and all packages installed by homebrew. If you prefer to manually update packages via `brew` commands, leave this set to `false`.
 
+
+    homebrew_cask_upgrade_all_packages: false
+
+Whether to upgrade homebrew and all cask applications installed by homebrew. If you prefer to manually update packages via `brew` commands, leave this set to `false`.
+
     homebrew_taps:
       - homebrew/core
       - { name: my_company/internal_tap, url: 'https://example.com/path/to/tap.git' }

--- a/roles/homebrew/defaults/main.yml
+++ b/roles/homebrew/defaults/main.yml
@@ -10,6 +10,7 @@ homebrew_installed_packages: []
 homebrew_uninstalled_packages: []
 
 homebrew_upgrade_all_packages: false
+homebrew_cask_upgrade_all_packages: false
 
 homebrew_taps:
   - homebrew/core

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -136,6 +136,18 @@
       notify:
         - Clear homebrew cache
 
+    - name: Upgrade all cask applications (if configured).
+      homebrew_cask:
+        install_options: "{{ item.install_options | default('appdir=' + homebrew_cask_appdir) }}"
+        accept_external_apps: "{{ homebrew_cask_accept_external_apps }}"
+        sudo_password: "{{ ansible_become_password | default(omit) }}"
+        update_homebrew: true
+        upgrade_all: true
+        greedy: true
+      when: homebrew_cask_upgrade_all_packages
+      notify:
+        - Clear homebrew cache
+
     # Brew.
     - name: Ensure blacklisted homebrew packages are not installed.
       homebrew: "name={{ item }} state=absent"


### PR DESCRIPTION
Hi

I had an issue with upgrading as some casks weren't upgraded. I tried to use the cu plugin to upgrade all the casks, including those who wouldn't be upgraded as they are marked as "auto_upgrade". I used this command in my playbook: `brew cu -a -y`

But I think it should be part of this role, therefore I submit this PR. I tested it locally here. 

Before the test:
```
$ brew outdated --cask --greedy
font-roboto (latest) != latest
font-roboto-mono (latest) != latest
webex-meetings (2211.1803.4212.2) != latest
wireshark (4.0.2) != 4.0.10
```

After the test:
```
$ brew outdated --cask --greedy
font-roboto (latest) != latest
font-roboto-mono (latest) != latest
```

I've no idea about the fonts. Probably there's an issue with the version being latest.

This PR adds a task to the cask part like it already exists in the brew part. It has a similar variable to enable it, and like the task in the brew part, it's disabled by default.

Br