### PR TITLE
Add optional sudo password for uninstalling casks

### DIFF
--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -122,7 +122,7 @@
 
     # Cask.
     - name: Ensure blacklisted cask applications are not installed.
-      homebrew_cask: "name={{ item }} state=absent"
+      homebrew_cask: "name={{ item }} state=absent sudo_password={{ ansible_become_password | default(omit)}}"
       loop: "{{ homebrew_cask_uninstalled_apps }}"
 
     - name: Install configured cask applications.


### PR DESCRIPTION
Some Homebrew casks require sudo to uninstall them (e.g.: Zenmap, Wireshark etc..)

Since the role already uses `sudo_password: "{{ ansible_become_password | default(omit) }}"` construction for installing casks, it would make sense to add the same option for uninstalling casks too.

P.S.: Thank you very much for this collection.