### PR TITLE
Update(dock): Fixed dockutil install and added pause for position setting

### DIFF
--- a/roles/dock/defaults/main.yml
+++ b/roles/dock/defaults/main.yml
@@ -14,7 +14,8 @@ dockitems_persist: []
 #   pos: 5
 
 # Which homebrew cask to install for dockutil
-dockutil_homebrew_cask: hpedrorodrigues/tools/dockutil
+dockutil_homebrew_tap: hpedrorodrigues/tools
+dockutil_homebrew_cask: dockutil
 
 # Whether to install dockutil or not
 dockutil_install: true

--- a/roles/dock/defaults/main.yml
+++ b/roles/dock/defaults/main.yml
@@ -14,8 +14,7 @@ dockitems_persist: []
 #   pos: 5
 
 # Which homebrew cask to install for dockutil
-dockutil_homebrew_tap: hpedrorodrigues/tools
-dockutil_homebrew_cask: dockutil
+dockutil_homebrew_cask: hpedrorodrigues/tools/dockutil
 
 # Whether to install dockutil or not
 dockutil_install: true

--- a/roles/dock/tasks/dock-position.yml
+++ b/roles/dock/tasks/dock-position.yml
@@ -14,3 +14,8 @@
   ansible.builtin.command:
     cmd: dockutil --move '{{ item.name | default(item) }}' --position '{{ item.pos }}'
   when: current_position|int != item.pos|int
+
+- name: Pause for 7 seconds between dock changes.
+  ansible.builtin.pause:
+    seconds: 7
+  when: current_position|int != item.pos|int

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -5,7 +5,7 @@
     name: "{{ dockutil_homebrew_cask }}"
     state: present
     accept_external_apps: true
-    sudo_password: "{{ ANSIBLE_BECOME_PASSWORD | default(omit) }}"
+    sudo_password: "{{ ansible_become_password | default(omit) }}"
   notify:
     - Clear homebrew cache
   when: dockutil_install

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -4,8 +4,6 @@
   community.general.homebrew_cask:
     name: "{{ dockutil_homebrew_cask }}"
     state: present
-    accept_external_apps: true
-    sudo_password: "{{ ansible_become_password | default(omit) }}"
   notify:
     - Clear homebrew cache
   when: dockutil_install

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 # See: https://github.com/kcrawford/dockutil/issues/127
-- name: Install dockutil.
+- name: Install dockutil
+  become: "{{ (homebrew_user != ansible_user_id) | bool }}"
+  become_user: "{{ homebrew_user }}"
   community.general.homebrew_cask:
     name: "{{ dockutil_homebrew_cask }}"
     state: present

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -4,6 +4,7 @@
   community.general.homebrew_cask:
     name: "{{ dockutil_homebrew_cask }}"
     state: present
+    accept_external_apps: true
     sudo_password: "{{ ansible_become_password | default(omit) }}"
   notify:
     - Clear homebrew cache

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -4,11 +4,10 @@
   community.general.homebrew_cask:
     name: "{{ dockutil_homebrew_cask }}"
     state: present
-    accept_external_apps: true
-    sudo_password: "{{ ansible_become_password | default(omit) }}"
   notify:
     - Clear homebrew cache
   when: dockutil_install
+  become: true
   tags: ['dock']
 
 - name: Remove configured Dock items.

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -4,6 +4,7 @@
   community.general.homebrew_cask:
     name: "{{ dockutil_homebrew_cask }}"
     state: present
+    sudo_password: "{{ ansible_become_password | default(omit) }}"
   notify:
     - Clear homebrew cache
   when: dockutil_install

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -10,6 +10,8 @@
   community.general.homebrew_cask:
     name: "{{ dockutil_homebrew_cask }}"
     state: present
+    install_options: 'appdir=/Applications'
+    accept_external_apps: false
     sudo_password: "{{ ansible_become_password | default(omit) }}"
   notify:
     - Clear homebrew cache

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -1,9 +1,16 @@
 ---
 # See: https://github.com/kcrawford/dockutil/issues/127
+
+- name: Tap dockutil.
+  community.general.homebrew_tap:
+    tap: "{{ dockutil_homebrew_tap }}"
+    state: present
+
 - name: Install dockutil.
   community.general.homebrew_cask:
     name: "{{ dockutil_homebrew_cask }}"
     state: present
+    sudo_password: "{{ ansible_become_password | default(omit) }}"
   notify:
     - Clear homebrew cache
   when: dockutil_install

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -4,10 +4,11 @@
   community.general.homebrew_cask:
     name: "{{ dockutil_homebrew_cask }}"
     state: present
+    accept_external_apps: true
+    sudo_password: "{{ ANSIBLE_BECOME_PASSWORD | default(omit) }}"
   notify:
     - Clear homebrew cache
   when: dockutil_install
-  become: true
   tags: ['dock']
 
 - name: Remove configured Dock items.

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -1,18 +1,9 @@
 ---
 # See: https://github.com/kcrawford/dockutil/issues/127
-
-- name: Tap dockutil.
-  community.general.homebrew_tap:
-    tap: "{{ dockutil_homebrew_tap }}"
-    state: present
-
 - name: Install dockutil.
   community.general.homebrew_cask:
     name: "{{ dockutil_homebrew_cask }}"
     state: present
-    install_options: 'appdir=/Applications'
-    accept_external_apps: false
-    sudo_password: "{{ ansible_become_password | default(omit) }}"
   notify:
     - Clear homebrew cache
   when: dockutil_install


### PR DESCRIPTION
I added a become and become_user option that matches the homebrew role without it the dockutil fails to install and will prompt for password in the middle of the play even with `--ask-become-pass` being passed. This fixes the install issue.

Added a sleep in the position setting task that matches the others, without it I was having a lot of issues with position getting set reliably.