### PR TITLE
stop tapping homebrew/core

### DIFF
--- a/roles/homebrew/README.md
+++ b/roles/homebrew/README.md
@@ -39,7 +39,6 @@ Packages you would like to make sure are _uninstalled_.
 Whether to upgrade homebrew and all packages installed by homebrew. If you prefer to manually update packages via `brew` commands, leave this set to `false`.
 
     homebrew_taps:
-      - homebrew/core
       - { name: my_company/internal_tap, url: 'https://example.com/path/to/tap.git' }
 
 Taps you would like to make sure Homebrew has tapped.

--- a/roles/homebrew/defaults/main.yml
+++ b/roles/homebrew/defaults/main.yml
@@ -11,8 +11,7 @@ homebrew_uninstalled_packages: []
 
 homebrew_upgrade_all_packages: false
 
-homebrew_taps:
-  - homebrew/core
+homebrew_taps: []
 
 homebrew_cask_apps: []
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -14,7 +14,6 @@
       - google-chrome  # from hombrew/cask
 
     homebrew_taps:
-      - homebrew/core
       - name: denji/nginx
         url: 'https://github.com/denji/homebrew-nginx.git'
 


### PR DESCRIPTION
Homebrew throws an error otherwise. 
Apparently, tapping homebrew/core [is no longer necessary](https://github.com/Homebrew/brew/commit/b42256d28677ba1f3ebf43e685c964f69c0e9dbe#).

This would close #85 .