### PR TITLE
 Stick to defaults - update homebrew_install_path

### DIFF
--- a/roles/homebrew/README.md
+++ b/roles/homebrew/README.md
@@ -15,11 +15,11 @@ Available variables are listed below, along with default values (see [`defaults/
 The GitHub repository for Homebrew core.
 
     homebrew_prefix: "{{ (ansible_machine == 'arm64') | ternary('/opt/homebrew', '/usr/local') }}"
-    homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
+    homebrew_install_path: "{{ homebrew_prefix }}{{ '/Homebrew' if ansible_machine != 'arm64' }}"
 
-The path where Homebrew will be installed (`homebrew_prefix` is the parent directory). It is recommended you stick to the default, otherwise Homebrew might have some weird issues. If you change this variable, you should also manually create a symlink back to /usr/local so things work as Homebrew expects.
+The path where Homebrew will be installed (`homebrew_prefix` is the parent directory). It is recommended you stick to the default, otherwise Homebrew might have some weird issues. If you change this variable, you should also manually create a symlink back to `/opt/homebrew` (or `/usr/local` if you're on an Intel-mac) so things work as Homebrew expects.
 
-    homebrew_brew_bin_path: /usr/local/bin
+    homebrew_brew_bin_path: {{ homebrew_prefix }}/bin
 
 The path where `brew` will be installed.
 

--- a/roles/homebrew/defaults/main.yml
+++ b/roles/homebrew/defaults/main.yml
@@ -2,7 +2,7 @@
 homebrew_repo: https://github.com/Homebrew/brew
 
 homebrew_prefix: "{{ (ansible_machine == 'arm64') | ternary('/opt/homebrew', '/usr/local') }}"
-homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
+homebrew_install_path: "{{ homebrew_prefix }}{{ '/Homebrew' if ansible_machine != 'arm64' }}"
 homebrew_brew_bin_path: "{{ homebrew_prefix }}/bin"
 
 homebrew_installed_packages: []

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -88,6 +88,11 @@
   when: not homebrew_binary.stat.exists
   become: true
 
+- name: Add missing folder if not on Apple-chipset
+  set_fact:
+    homebrew_folders_base: "{{ homebrew_folders_base + ['Homebrew'] }}"
+  when: ansible_machine != 'arm64'
+
 - name: Ensure proper homebrew folders are in place.
   file:
     path: "{{ homebrew_prefix }}/{{ item }}"

--- a/roles/homebrew/vars/main.yml
+++ b/roles/homebrew/vars/main.yml
@@ -1,7 +1,6 @@
 ---
 homebrew_folders_base:
   - Cellar
-  - Homebrew
   - Frameworks
   - Caskroom
   - bin


### PR DESCRIPTION


As the README says [1], it is recommended to stick to the defaults. The default install path is `/opt/homebrew` on macs with Apple-chipsets [2], not `/opt/homebrew/Homebrew`.

1: <https://github.com/geerlingguy/ansible-collection-mac/blob/master/roles/homebrew/README.md?plain=1#L20>
2: <https://github.com/Homebrew/install/blob/master/install.sh#L151-L160>

The second commit makes sure `/opt/homebrew/Homebrew` isn't created on macs with Apple-chipsets.