### PR TITLE
dockutil is now available directly, without cask

### DIFF
--- a/roles/dock/README.md
+++ b/roles/dock/README.md
@@ -23,12 +23,6 @@ dockitems_persist: []
 Dock items to add. `pos` parameter is optional and will place the Dock item in a particular position in the Dock.
 
 ```yaml
-dockutil_homebrew_cask: hpedrorodrigues/tools/dockutil
-```
-
-Which Homebrew cask to install for dockutil. See [this issue](https://github.com/kcrawford/dockutil/issues/127) to read more about why this cask is the default.
-
-```yaml
 dockutil_install: true
 ```
 

--- a/roles/dock/defaults/main.yml
+++ b/roles/dock/defaults/main.yml
@@ -13,8 +13,5 @@ dockitems_persist: []
 #   path: "/Applications/Sublime Text.app/"
 #   pos: 5
 
-# Which homebrew cask to install for dockutil
-dockutil_homebrew_cask: hpedrorodrigues/tools/dockutil
-
 # Whether to install dockutil or not
 dockutil_install: true

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
-# See: https://github.com/kcrawford/dockutil/issues/127
 - name: Install dockutil.
-  community.general.homebrew_cask:
-    name: "{{ dockutil_homebrew_cask }}"
+  community.general.homebrew:
+    name: dockutil
     state: present
   notify:
     - Clear homebrew cache


### PR DESCRIPTION
[This issue](https://github.com/kcrawford/dockutil/issues/127) has been updated, and dockutil can now be installed without the extra cask-step