### PR TITLE
Add explicit checkout directory #94

### DIFF
--- a/roles/homebrew/defaults/main.yml
+++ b/roles/homebrew/defaults/main.yml
@@ -2,7 +2,7 @@
 homebrew_repo: https://github.com/Homebrew/brew
 
 homebrew_prefix: "{{ (ansible_machine == 'arm64') | ternary('/opt/homebrew', '/usr/local') }}"
-homebrew_install_path: "{{ homebrew_prefix }}{{ '/Homebrew' if ansible_machine != 'arm64' }}"
+homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
 homebrew_brew_bin_path: "{{ homebrew_prefix }}/bin"
 
 homebrew_installed_packages: []

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -49,7 +49,7 @@
     repo: "{{ homebrew_repo }}"
     version: master
     dest: "{{ homebrew_install_path }}"
-    update: false
+    update: true
     depth: 1
   become: true
   become_user: "{{ homebrew_user }}"


### PR DESCRIPTION
Adds the ability to check out over an existing checkout.  Tested on an arm machine.
Related to this Ansible git issue: https://github.com/ansible/ansible/issues/29465#issuecomment-702766762