### PR TITLE
Only restart dock between commands #53

### DIFF
--- a/roles/dock/tasks/dock-add.yml
+++ b/roles/dock/tasks/dock-add.yml
@@ -15,14 +15,18 @@
   tags: ['dock']
 
 - name: Ensure Dock item {{ item.name | default(item) }} exists.
-  ansible.builtin.command: "dockutil --add '{{ item.path }}' --label '{{ item.name }}'"
-  when: dockitem_exists.rc >0 or
+  ansible.builtin.command: |
+    dockutil --add '{{ item.path }}' --label '{{ item.name }}'
+    {% if not ansible_loop.last %}--no-restart{% endif %}
+  when: dockitem_exists.rc > 0 or
         dockitem_exists.rc == 0 and current_section == 'recent-apps'
   tags: ['dock']
 
 - name: Pause for 7 seconds between dock changes.
   ansible.builtin.pause:
     seconds: 7
-  when: dockitem_exists.rc >0 or
-        dockitem_exists.rc == 0 and current_section == 'recent-apps'
+  when:
+    - dockitem_exists.rc > 0 or
+      dockitem_exists.rc == 0 and current_section == 'recent-apps'
+    - ansible_loop.last
   tags: ['dock']

--- a/roles/dock/tasks/dock-position.yml
+++ b/roles/dock/tasks/dock-position.yml
@@ -12,5 +12,7 @@
 
 - name: Move dock item to the correct position.
   ansible.builtin.command:
-    cmd: dockutil --move '{{ item.name | default(item) }}' --position '{{ item.pos }}'
+    cmd: |
+      dockutil --move '{{ item.name | default(item) }}' --position '{{ item.pos }}'
+      {% if not ansible_loop.last %}--no-restart{% endif %}
   when: current_position|int != item.pos|int

--- a/roles/dock/tasks/dock-remove.yml
+++ b/roles/dock/tasks/dock-remove.yml
@@ -11,12 +11,16 @@
 
 - name: Ensure Dock item {{ item }} is removed.
   ansible.builtin.command:
-    cmd: dockutil --remove '{{ item }}'
+    cmd: |
+      dockutil --remove '{{ item }}'
+      {% if not ansible_loop.last %}--no-restart{% endif %}
   when: dockitem_exists.rc  == 0
   tags: ['dock']
 
 - name: Pause for 7 seconds between dock changes.
   ansible.builtin.pause:
     seconds: 7
-  when: dockitem_exists.rc == 0
+  when:
+    - dockitem_exists.rc == 0
+    - ansible_loop.last
   tags: ['dock']

--- a/roles/dock/tasks/main.yml
+++ b/roles/dock/tasks/main.yml
@@ -11,11 +11,17 @@
 - name: Remove configured Dock items.
   ansible.builtin.include_tasks: dock-remove.yml
   loop: "{{ dockitems_remove }}"
+  loop_control:
+    extended: true
+    extended_allitems: false
   tags: ['dock']
 
 - name: Ensure required dock items exist.
   ansible.builtin.include_tasks: dock-add.yml
   loop: "{{ dockitems_persist }}"
+  loop_control:
+    extended: true
+    extended_allitems: false
   tags: ['dock']
 
 - name: Ensure dock items are in correct position.
@@ -24,4 +30,7 @@
     - item.pos is defined
     - item.pos > 0
   loop: "{{ dockitems_persist }}"
+  loop_control:
+    extended: true
+    extended_allitems: false
   tags: ['dock']

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -34,6 +34,11 @@
       become: true
       when: "ansible_distribution_version is version('10.13', '<')"
 
+- name: Check if homebrew already exists.
+  stat:
+    path: "{{ homebrew_brew_bin_path }}/brew"
+  register: pre_installed_brew
+
 - name: Ensure Homebrew directory exists.
   file:
     path: "{{ homebrew_install_path }}"
@@ -114,7 +119,7 @@
   block:
     - name: Force update brew after installation.
       command: "{{ homebrew_brew_bin_path }}/brew update --force"
-      when: not homebrew_binary.stat.exists
+      when: not pre_installed_brew.stat.exists
 
     - name: Where is the cache?
       command: "{{ homebrew_brew_bin_path }}/brew --cache"

--- a/tests/uninstall-homebrew.sh
+++ b/tests/uninstall-homebrew.sh
@@ -11,3 +11,4 @@ sudo ./uninstall.sh --force
 sudo rm -rf /usr/local/Homebrew
 sudo rm -rf /usr/local/Caskroom
 sudo rm -rf /usr/local/bin/brew
+sudo rm -rf /opt/homebrew


### PR DESCRIPTION
Includes changes to add `--no-restart` flag for dock operations except for the last iteration, reducing the total pause time when changing multiple dock items.

Also includes a change to force update brew after a new installation, which also fixes a problem with the CI. This adds a stat to check for an existing brew binary using `homebrew_brew_bin_path`,  before cloning homebrew.

Related Issue #53 