### PR TITLE
Don't follow symlinks when setting Homebrew permissions

### DIFF
--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -76,6 +76,7 @@
     owner: "{{ homebrew_user }}"
     group: "{{ homebrew_group }}"
     recurse: true
+    follow: false
   become: true
 
 # Place brew binary in proper location and complete setup.


### PR DESCRIPTION
This PR fixes #107 and #93.

In short, this changes the task which sets the permissions on `/opt/homebrew` or `/usr/local/Homebrew` subdirectories so that it no longer follows symlinks.

For a more detailed explanation, [see my comment in #107 here](https://github.com/geerlingguy/ansible-collection-mac/issues/107#issuecomment-2259713892).

I have tested this on my machine (M2) but I do not have access to an x86 machine to test on.