### PR TITLE
Git fails if Homebrew is already installed

### DIFF
--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -58,6 +58,7 @@
     depth: 1
   become: true
   become_user: "{{ homebrew_user }}"
+  when: not pre_installed_brew.stat.exists
 
 # Adjust Homebrew permissions.
 - name: Ensure proper permissions and ownership on homebrew_brew_bin_path dirs.


### PR DESCRIPTION
If brew is already installed, don't need to pull it again, the command fails and the system bails out.