### PR TITLE
Set mas_path variable to fix mas not found issue when using remote Mac as target

### DIFF
--- a/roles/mas/README.md
+++ b/roles/mas/README.md
@@ -38,6 +38,10 @@ A list of apps to ensure are installed on the computer using the Mac App Store. 
 
 Whether to run `mas upgrade`, which will upgrade all installed Mac App Store apps.
 
+    mas_path: "{{ '/opt/homebrew/bin/mas' if ansible_architecture == 'arm64' else '/usr/local/bin/mas' }}"
+
+When targeting a remote Mac, the PATH isn't always correct leading to the `mas` binary not being found. This variable allows you to override the path to the `mas` binary. The defaults above work for most installations, but you may need to override this if you have a custom Homebrew installation path or other custom setup.
+
 ### Remove installed apps
 
     mas_uninstalled_apps:

--- a/roles/mas/defaults/main.yml
+++ b/roles/mas/defaults/main.yml
@@ -2,11 +2,12 @@
 mas_email: ""
 mas_password: ""
 mas_uninstalled_apps: []
-mas_installed_app_ids: []  # Deprecated
+mas_installed_app_ids: [] # Deprecated
 mas_installed_apps:
-  - {id: 425264550, name: "Blackmagic Disk Speed Test (3.0)"}
-  - {id: 411643860, name: "DaisyDisk (4.3.2)"}
-  - {id: 498486288, name: "Quick Resizer (1.9)"}
-  - {id: 497799835, name: "Xcode (8.1)"}
+  - { id: 425264550, name: "Blackmagic Disk Speed Test (3.0)" }
+  - { id: 411643860, name: "DaisyDisk (4.3.2)" }
+  - { id: 498486288, name: "Quick Resizer (1.9)" }
+  - { id: 497799835, name: "Xcode (8.1)" }
 mas_upgrade_all_apps: false
 mas_signin_dialog: false
+mas_path: "{{ '/opt/homebrew/bin/mas' if ansible_architecture == 'arm64' else '/usr/local/bin/mas' }}"

--- a/roles/mas/tasks/main.yml
+++ b/roles/mas/tasks/main.yml
@@ -5,7 +5,7 @@
     state: present
 
 - name: Get MAS account status
-  command: mas account
+  command: '"{{ mas_path }}" account'
   register: mas_account_result
   failed_when: mas_account_result.rc > 1
   check_mode: false
@@ -14,7 +14,7 @@
     - ansible_distribution_version is version('12', '<')
 
 - name: Sign in to MAS when email and password are provided.
-  command: 'mas signin "{{ mas_email }}" "{{ mas_password }}"'
+  command: '"{{ mas_path }}" signin "{{ mas_email }}" "{{ mas_password }}"'
   register: mas_signin_result
   when:
     - ansible_distribution_version is version('10.13', '<')
@@ -24,7 +24,7 @@
     - not mas_signin_dialog
 
 - name: Sign in to MAS when email is provided, and complete password and 2FA using dialog.
-  command: 'mas signin "{{ mas_email }}" "{{ mas_password }}" --dialog'
+  command: '"{{ mas_path }}" signin "{{ mas_email }}" "{{ mas_password }}" --dialog'
   register: mas_signin_result
   when:
     - ansible_distribution_version is version('10.13', '<')
@@ -33,21 +33,21 @@
     - mas_email is truthy
 
 - name: List installed MAS apps.
-  command: mas list
+  command: '"{{ mas_path }}" list'
   register: mas_list
   check_mode: false
   changed_when: false
 
 - name: Ensure unwanted MAS apps are uninstalled.
-  command: mas uninstall "{{ item.id | default(item) }}"
+  command: '"{{ mas_path }}" uninstall "{{ item.id | default(item) }}"'
   with_items: "{{ mas_uninstalled_apps }}"
   when: (item.id | default(item) | string) in mas_list.stdout
 
 - name: Ensure configured MAS apps are installed.
-  command: mas install "{{ item.id | default(item) }}"
+  command: '"{{ mas_path }}" install "{{ item.id | default(item) }}"'
   with_items: "{{ mas_installed_apps + mas_installed_app_ids }}"
   when: (item.id | default(item) | string) not in mas_list.stdout
 
 - name: Upgrade all apps (if configured).
-  command: mas upgrade
+  command: '"{{ mas_path }}" upgrade'
   when: mas_upgrade_all_apps


### PR DESCRIPTION
- Fixes #86
- Set `mas_path` to /opt/homebrew/bin/mas for apple silicone and /usr/local/bin/mas for Intel.
- Use `mas_path` variable in the mas role tasks.
- Tested against an Intel Mac and an M1 Mac.